### PR TITLE
memory expansion step

### DIFF
--- a/src/yolo_evm/memory.py
+++ b/src/yolo_evm/memory.py
@@ -1,5 +1,11 @@
 from .constants import MAX_UINT256, MAX_UINT8
 
+ZERO_WORD = [0] * 32
+
+# thanks, https://stackoverflow.com/questions/14822184/is-there-a-ceiling-equivalent-of-operator-in-python
+def ceildiv(a, b):
+    return -(a // -b)
+
 
 class Memory:
     def __init__(self) -> None:
@@ -13,27 +19,48 @@ class Memory:
         if value < 0 or value > MAX_UINT8:
             raise InvalidMemoryValue({"offset": offset, "value": value})
 
-        # expand memory if needed
-        if offset >= len(self.memory):
-            self.memory.extend([0] * (32 - (offset % 32)))
-
+        self._expand_if_needed(offset)
         self.memory[offset] = value
 
     def load(self, offset: int) -> int:
         if offset < 0:
             raise InvalidMemoryAccess({"offset": offset})
 
-        if offset >= len(self.memory):
-            return 0
-
+        self._expand_if_needed(offset)
         return self.memory[offset]
 
     def load_range(self, offset: int, length: int) -> bytes:
         if offset < 0:
             raise InvalidMemoryAccess({"offset": offset, "length": length})
 
-        # we could use a slice here, but this lets us gets 0 bytes if we read past the end of concrete memory
-        return bytes(self.load(x) for x in range(offset, offset + length))
+        self._expand_if_needed(offset + length - 1)
+
+        return bytes(self.memory[offset : offset + length])
+
+    def active_words(self) -> int:
+        return len(self.memory) // 32
+
+    # per the definition of MSTORE8 and MLOAD in the yellow paper, the number of active words is
+    # expanded when both reading and writing a previously untouched memory location
+    # MLOAD:
+    #   μ′i ≡ max(μi,⌈(μs[0]+32)÷32⌉)
+    # MSTORE8:
+    #   μ′i ≡ max(μi, ⌈(μs[0]+1)÷32⌉)
+    #
+    # human-readable Solidity docs:
+    # https://docs.soliditylang.org/en/latest/introduction-to-smart-contracts.html#storage-memory-and-the-stack
+    def _expand_if_needed(self, offset: int) -> None:
+        if offset < len(self.memory):
+            return
+
+        active_words_after = max(self.active_words(), ceildiv(offset + 1, 32))
+
+        self.memory.extend(ZERO_WORD * (active_words_after - self.active_words()))
+
+        assert len(self.memory) % 32 == 0
+
+    def __len__(self) -> int:
+        return len(self.memory)
 
     def __str__(self) -> str:
         return str(self.memory)

--- a/src/yolo_evm/memory.py
+++ b/src/yolo_evm/memory.py
@@ -15,7 +15,7 @@ class Memory:
 
         # expand memory if needed
         if offset >= len(self.memory):
-            self.memory.extend([0] * (offset - len(self.memory) + 1))
+            self.memory.extend([0] * (32 - (offset % 32)))
 
         self.memory[offset] = value
 

--- a/src/yolo_evm/opcodes.py
+++ b/src/yolo_evm/opcodes.py
@@ -24,7 +24,7 @@ class Instruction:
 
 class DuplicateOpcode(Exception):
     ...
-    
+
 
 INSTRUCTIONS = []
 INSTRUCTIONS_BY_OPCODE = {}


### PR DESCRIPTION
evm memory is expanded by a word i.e. 32-byte when accessing a previously untouched memory. [relevant docs](https://docs.soliditylang.org/en/latest/introduction-to-smart-contracts.html#storage-memory-and-the-stack)